### PR TITLE
Correct configuration docs

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -41,13 +41,13 @@ module.exports = ({ platform }, defaults) => ({
   entry: `./index.${platform}.js`,
   module: {
     ...defaults.module,
-    rules: {
+    rules: [
       ...defaults.module.rules,
       {
         test: /\.js$/,
         use: 'custom-loader',
       }
-    },
+    ],
   },
   resolve: {
     ...defaults.resolve,

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -42,7 +42,7 @@ module.exports = ({ platform }, defaults) => ({
   module: {
     ...defaults.module,
     rules: {
-      ...defaults.rules,
+      ...defaults.module.rules,
       {
         test: /\.js$/,
         use: 'custom-loader',


### PR DESCRIPTION
This one had me puzzled. I followed the configuration docs to start customizing my project. I copy/pasted the last code example, changed the `rules` key to be an array (as webpack requires), and removed the custom bits in order to test:

```
module.exports = ({ platform }, defaults) => ({
  entry: `./index.${platform}.js`,
  module: {
    ...defaults.module,
    rules: [
      ...defaults.rules
    ]
  },
  resolve: {
    ...defaults.resolve
  }
});
```

I then received the following error:

<img width="851" alt="screen shot 2017-03-31 at 6 18 30 am" src="https://cloud.githubusercontent.com/assets/1819798/24546581/ea988d3a-15d9-11e7-86f5-9e91d6dd0049.png">


Turns out the `...defaults.rules` spread should actually be `...defaults.module.rules`. Took me a while to figure that out :)