### PR TITLE
Add to package.json scripts

### DIFF
--- a/src/commands/init.js
+++ b/src/commands/init.js
@@ -162,8 +162,9 @@ const addToPackageScripts = async (cwd: string) => {
 
   const scripts = pjson.scripts || {};
 
-  const haulScript = Object.keys(scripts).find(name =>
-    scripts[name].includes('haul'));
+  const haulScript = Object.keys(scripts).find(
+    name => scripts[name] === 'haul start',
+  );
 
   if (haulScript) {
     ora().info(
@@ -182,8 +183,8 @@ const addToPackageScripts = async (cwd: string) => {
       {
         type: 'input',
         name: 'scriptName',
-        message: 'Enter the name of the script to add to package.json',
-        default: scriptName,
+        message: 'Enter the name of the script to add to package.json, e.g. `haul` for `yarn run haul`',
+        default: 'haul',
       },
     ]);
 

--- a/src/commands/init.js
+++ b/src/commands/init.js
@@ -167,7 +167,7 @@ const addToPackageScripts = async (cwd: string) => {
 
   if (haulScript) {
     ora().info(
-      `Haul is already in your package's scripts. You can start it by running '${getRunScript(haulScript)}'`,
+      `Haul already exists in your package.json. Start Haul by running ${getRunScript(haulScript)}'`,
     );
     return;
   }
@@ -182,7 +182,7 @@ const addToPackageScripts = async (cwd: string) => {
       {
         type: 'input',
         name: 'scriptName',
-        message: 'Enter name of script to add to package.json',
+        message: 'Enter the name of the script to add to package.json',
         default: scriptName,
       },
     ]);

--- a/src/commands/init.js
+++ b/src/commands/init.js
@@ -147,7 +147,7 @@ async function init() {
 const sleep = (time: number = 1000) =>
   new Promise(resolve => setTimeout(resolve, time));
 
-const getRunScript = scriptName => {
+const getRunScript = (scriptName: string) => {
   const runCommand = scriptName === 'start' ? 'yarn' : 'yarn run';
   return `${runCommand} ${scriptName}`;
 };
@@ -203,7 +203,7 @@ const addToPackageScripts = async (cwd: string) => {
   fs.writeFileSync(path.join(cwd, 'package.json'), JSON.stringify(pjson));
 
   progress.succeed(
-    `You can now start Haul by running '${getRunScript(haulScript)}'`,
+    `You can now start Haul by running '${getRunScript(scriptName)}'`,
   );
 };
 


### PR DESCRIPTION
Fixes #85

The process is:

1) If Haul is already in `package.json` scripts (any of scripts contains haul), we print info that it's already there and how to run it

2) If there's start script defined already and is not a default packager, we ask for a name for Haul script. By default it's start so users can opt-in to overwrite it

3) We use either start or name provided in point 2 to write package.json.

Questions:

1) Currently we add `haul start`. As of now, one has to pass `-- --platform [ios|android|all]` in order to start Haul for these platforms. Shall we print that as well?