### PR TITLE
Fix debugger issues on Android

### DIFF
--- a/src/commands/start.js
+++ b/src/commands/start.js
@@ -101,7 +101,7 @@ async function start(opts: *) {
     }
   }
 
-  app.listen(opts.port, '127.0.0.1', () => {
+  app.listen(opts.port, () => {
     logger.info(
       messages.initialStartInformation({
         entries: Array.isArray(config)

--- a/src/server/middleware/devToolsMiddleware.js
+++ b/src/server/middleware/devToolsMiddleware.js
@@ -64,7 +64,7 @@ function devToolsMiddleware(debuggerProxy) {
        */
       case '/launch-js-devtools': {
         if (!debuggerProxy.isDebuggerConnected()) {
-          launchChrome(`http://${req.get('host')}/debugger-ui`);
+          launchChrome(`http://localhost:${req.socket.localPort}/debugger-ui`);
         }
         res.end('OK');
         break;


### PR DESCRIPTION
Fixes `debugger-ui` being opened on a wrong IP (typically `10.0.3.2` in Genymotion because of using `hostname`).