### PR TITLE
Fix iOS build phase

### DIFF
--- a/src/commands/init.js
+++ b/src/commands/init.js
@@ -313,7 +313,7 @@ const addToXcodeBuild = async (cwd: string) => {
     );
   });
 
-  if (sectionsCount === 0) {
+  if (sectionsCount > 0) {
     fs.writeFileSync(path.join(entry, 'project.pbxproj'), project);
     progress.succeed('Added haul to your Xcode build scripts');
   } else {


### PR DESCRIPTION
In this commit https://github.com/callstack-io/haul/pull/90/commits/afd93e1b42c050b9690d81419464e5ceb819ffb2 @grabbou changed the comparison from `>` to `===`.
I don't know if it was intended but it broke the script. If a section is matched and replaced it doesn't save but exits with an error.