### PR TITLE
dev is true by default in `start`

### DIFF
--- a/src/commands/start.js
+++ b/src/commands/start.js
@@ -124,6 +124,7 @@ module.exports = {
     {
       name: 'dev',
       description: 'Whether to build in development mode',
+      default: true,
       parse: (val: string) => val !== 'false',
       choices: [
         {


### PR DESCRIPTION
We forgot to define it after changing CLI interface. Results in `uglify` running for `npm start`.