### PR TITLE
Remove body-parser in favor of rawBodyMiddleware

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "babel-preset-env": "^1.2.2",
     "babel-preset-react-native": "^1.9.1",
     "babel-register": "^6.24.0",
-    "body-parser": "^1.17.1",
     "camelcase-keys": "^4.0.0",
     "case-sensitive-paths-webpack-plugin": "^2.0.0",
     "chalk": "1.1.3",
@@ -52,10 +51,10 @@
     "ora": "^1.2.0",
     "progress-bar-webpack-plugin": "^1.9.3",
     "source-map": "^0.5.6",
+    "strip-ansi": "^3.0.1",
     "webpack": "^2.3.1",
     "webpack-dev-middleware": "^1.10.1",
-    "ws": "^2.2.2",
-    "strip-ansi": "^3.0.1"
+    "ws": "^2.2.2"
   },
   "devDependencies": {
     "babel-eslint": "^7.2.1",

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -8,7 +8,6 @@ import type { WebpackStats } from '../types';
 
 const express = require('express');
 const http = require('http');
-const bodyParser = require('body-parser');
 
 type InvalidCallback = (compilingAfterError: boolean) => void;
 type CompileCallback = (stats: WebpackStats) => void;
@@ -58,7 +57,6 @@ function createServer(
   // Middlewares
   appHandler
     .use(rawBodyMiddleware)
-    .use(bodyParser.text())
     .use(devToolsMiddleware(debuggerProxy))
     .use(liveReloadMiddleware(compiler))
     .use(statusPageMiddleware)

--- a/src/server/middleware/symbolicateMiddleware.js
+++ b/src/server/middleware/symbolicateMiddleware.js
@@ -78,12 +78,12 @@ function createSourceMapConsumer(compiler: *) {
  * Gets the stack frames that React Native wants us to convert.
  */
 function getRequestedFrames(req: $Request): ?ReactNativeStack {
-  if (typeof req.body !== 'string') {
+  if (typeof req.rawBody !== 'string') {
     return null;
   }
 
   try {
-    const payload: ReactNativeSymbolicateRequest = JSON.parse(req.body);
+    const payload: ReactNativeSymbolicateRequest = JSON.parse(req.rawBody);
     return payload.stack;
   } catch (err) {
     // should happen, but at least we won't die

--- a/yarn.lock
+++ b/yarn.lock
@@ -895,21 +895,6 @@ bn.js@^4.0.0, bn.js@^4.1.0, bn.js@^4.1.1, bn.js@^4.4.0:
   version "4.11.6"
   resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-4.11.6.tgz#53344adb14617a13f6e8dd2ce28905d1c0ba3215"
 
-body-parser@^1.17.1:
-  version "1.17.1"
-  resolved "https://registry.yarnpkg.com/body-parser/-/body-parser-1.17.1.tgz#75b3bc98ddd6e7e0d8ffe750dfaca5c66993fa47"
-  dependencies:
-    bytes "2.4.0"
-    content-type "~1.0.2"
-    debug "2.6.1"
-    depd "~1.1.0"
-    http-errors "~1.6.1"
-    iconv-lite "0.4.15"
-    on-finished "~2.3.0"
-    qs "6.4.0"
-    raw-body "~2.2.0"
-    type-is "~1.6.14"
-
 boom@2.x.x:
   version "2.10.1"
   resolved "https://registry.yarnpkg.com/boom/-/boom-2.10.1.tgz#39c8918ceff5799f83f9492a848f625add0c766f"
@@ -1034,10 +1019,6 @@ builtin-modules@^1.0.0, builtin-modules@^1.1.1:
 builtin-status-codes@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz#85982878e21b98e1c66425e03d0174788f569ee8"
-
-bytes@2.4.0:
-  version "2.4.0"
-  resolved "https://registry.yarnpkg.com/bytes/-/bytes-2.4.0.tgz#7d97196f9d5baf7f6935e25985549edd2a6c2339"
 
 caller-path@^0.1.0:
   version "0.1.0"
@@ -2353,10 +2334,6 @@ husky@^0.13.3:
 iconv-lite@0.4.13:
   version "0.4.13"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.13.tgz#1f88aba4ab0b1508e8312acc39345f36e992e2f2"
-
-iconv-lite@0.4.15:
-  version "0.4.15"
-  resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.15.tgz#fe265a218ac6a57cfe854927e9d04c19825eddeb"
 
 ieee754@^1.1.4:
   version "1.1.8"
@@ -3810,14 +3787,6 @@ range-parser@^1.0.3, range-parser@~1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/range-parser/-/range-parser-1.2.0.tgz#f49be6b487894ddc40dcc94a322f611092e00d5e"
 
-raw-body@~2.2.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/raw-body/-/raw-body-2.2.0.tgz#994976cf6a5096a41162840492f0bdc5d6e7fb96"
-  dependencies:
-    bytes "2.4.0"
-    iconv-lite "0.4.15"
-    unpipe "1.0.0"
-
 rc@^1.1.7:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/rc/-/rc-1.2.0.tgz#c7de973b7b46297c041366b2fd3d2363b1697c66"
@@ -4502,7 +4471,7 @@ ultron@~1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/ultron/-/ultron-1.1.0.tgz#b07a2e6a541a815fc6a34ccd4533baec307ca864"
 
-unpipe@1.0.0, unpipe@~1.0.0:
+unpipe@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/unpipe/-/unpipe-1.0.0.tgz#b2bf4ee8514aae6165b4817829d21b2ef49904ec"
 


### PR DESCRIPTION
This PR fixes #122 by removing the `body-parser` as suggested by @skellock and relying on `rawBodyMiddleware` for symbolication.