### PR TITLE
Fail gracefully on source mapping lookup

### DIFF
--- a/src/server/middleware/symbolicateMiddleware.js
+++ b/src/server/middleware/symbolicateMiddleware.js
@@ -121,6 +121,14 @@ function create(compiler: *): Middleware {
           column: originalFrame.column,
         });
 
+        // If lookup fails, we get the same shape object, but with
+        // all values set to null
+        if (lookup.source == null) {
+          // It is better to gracefully return the original frame
+          // than to throw an exception
+          return originalFrame;
+        }
+
         // convert the original source into an absolute path
         const mappedFile = lookup.source
           .replace('webpack:///~', path.resolve(root, 'node_modules'))


### PR DESCRIPTION
If input source mappings are incomplete, stack frame lookups can fail and return nully values. I have observed this when trying to set up Haul to load TypeScript files. This causes the symbolicate endpoint to fail with JS's peculiar version of a NPE.

![image](https://cloud.githubusercontent.com/assets/1242537/25154805/ff06d268-2489-11e7-8f2c-8b3add2a3840.png)

It would be better to return the original stack frame for mappings that cannot be resolved. Then at least the mappings that *were* resolved can be seen. The underlying cause of the incomplete mappings is kind of beside the point. Better some than none, right?

This PR turns this:

![image](https://cloud.githubusercontent.com/assets/1242537/25154744/c5035b40-2489-11e7-8b99-eabe9ac3217f.png)


into this:

![image](https://cloud.githubusercontent.com/assets/1242537/25154925/8d8082f0-248a-11e7-8636-aa319417596d.png)

Which, perhaps you'll agree, is a distinct improvement. Plus no nasty error messages in the webpack log.