### PR TITLE
remove babel

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
   "license": "MIT",
   "bugs": "https://github.com/callstack-io/haul/issues",
   "dependencies": {
-    "babel": "^6.23.0",
     "babel-core": "^6.24.0",
     "babel-loader": "^6.4.1",
     "babel-plugin-transform-flow-strip-types": "^6.22.0",


### PR DESCRIPTION
`npm WARN deprecated babel@6.23.0: In 6.x, the babel package has been deprecated in favor of babel-cli.`

babel doesn't seems to be used, so we can remove it to remove the warning when installing haul.