### PR TITLE
fix misplaced babel plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "babel-core": "^6.24.0",
     "babel-loader": "^6.4.1",
     "babel-plugin-transform-flow-strip-types": "^6.22.0",
+    "babel-plugin-transform-object-rest-spread": "^6.23.0",
     "babel-preset-env": "^1.2.2",
     "babel-preset-react-native": "^1.9.1",
     "babel-register": "^6.24.0",
@@ -58,7 +59,6 @@
   },
   "devDependencies": {
     "babel-eslint": "^7.2.1",
-    "babel-plugin-transform-object-rest-spread": "^6.23.0",
     "eslint": "^3.18.0",
     "eslint-config-airbnb": "^14.1.0",
     "eslint-config-prettier": "^1.5.0",


### PR DESCRIPTION
needed by `babel-register` so should be in `dependencies`