### PR TITLE
add config path as an option

### DIFF
--- a/docs/CLI Commands.md
+++ b/docs/CLI Commands.md
@@ -30,6 +30,10 @@ Whether to minify the bundle while serving. This will make the bundling process 
 
 Port on which the server should run. defaults to `8081`.
 
+### `--config [path]`
+
+Path to the webpack haul config. defaults to `webpack.haul.js`.
+
 ## `haul bundle`
 
 This generates the app bundle and assets for packaging the app.
@@ -57,3 +61,7 @@ Path to use for the bundle file. e.g. - `build/index.android.bundle`.
 ### `--assets-dest <string>`
 
 Path to the directory to store the assets. e.g. - `build/assets`.
+
+### `--config [path]`
+
+Path to the webpack haul config. defaults to `webpack.haul.js`.

--- a/src/commands/bundle.js
+++ b/src/commands/bundle.js
@@ -5,13 +5,13 @@
  * @flow
  */
 const path = require('path');
-const fs = require('fs');
 const webpack = require('webpack');
 const clear = require('clear');
 
 const { MessageError } = require('../errors');
 const messages = require('../messages');
 const makeReactNativeConfig = require('../utils/makeReactNativeConfig');
+const getWebpackConfig = require('../utils/getWebpackConfig');
 const logger = require('../logger');
 
 /**
@@ -19,15 +19,7 @@ const logger = require('../logger');
  */
 async function bundle(opts: *) {
   const directory = process.cwd();
-  const configPath = path.join(directory, opts.config);
-
-  if (!fs.existsSync(configPath)) {
-    throw new MessageError(
-      messages.webpackConfigNotFound({
-        directory,
-      }),
-    );
-  }
+  const configPath = getWebpackConfig(directory, opts.config);
 
   const [
     configs,

--- a/src/commands/bundle.js
+++ b/src/commands/bundle.js
@@ -19,7 +19,7 @@ const logger = require('../logger');
  */
 async function bundle(opts: *) {
   const directory = process.cwd();
-  const configPath = path.join(directory, 'webpack.haul.js');
+  const configPath = path.join(directory, opts.config);
 
   if (!fs.existsSync(configPath)) {
     throw new MessageError(
@@ -150,6 +150,11 @@ module.exports = {
     {
       name: 'assetsDest',
       description: 'Path to directory where to store assets, eg. /tmp/dist',
+    },
+    {
+      name: 'config',
+      description: 'Path to config file, eg. webpack.haul.js',
+      default: 'webpack.haul.js',
     },
   ],
 };

--- a/src/commands/start.js
+++ b/src/commands/start.js
@@ -6,14 +6,13 @@
  */
 const webpack = require('webpack');
 const path = require('path');
-const fs = require('fs');
 const clear = require('clear');
 
 const logger = require('../logger');
 const createServer = require('../server');
 const messages = require('../messages');
 const exec = require('../utils/exec');
-const { MessageError } = require('../errors');
+const getWebpackConfig = require('../utils/getWebpackConfig');
 
 const makeReactNativeConfig = require('../utils/makeReactNativeConfig');
 
@@ -22,15 +21,7 @@ const makeReactNativeConfig = require('../utils/makeReactNativeConfig');
  */
 async function start(opts: *) {
   const directory = process.cwd();
-  const configPath = path.join(directory, opts.config);
-
-  if (!fs.existsSync(configPath)) {
-    throw new MessageError(
-      messages.webpackConfigNotFound({
-        directory,
-      }),
-    );
-  }
+  const configPath = getWebpackConfig(directory, opts.config);
 
   // eslint-disable-next-line prefer-const
   let [config, platforms] = makeReactNativeConfig(

--- a/src/commands/start.js
+++ b/src/commands/start.js
@@ -22,7 +22,7 @@ const makeReactNativeConfig = require('../utils/makeReactNativeConfig');
  */
 async function start(opts: *) {
   const directory = process.cwd();
-  const configPath = path.join(directory, 'webpack.haul.js');
+  const configPath = path.join(directory, opts.config);
 
   if (!fs.existsSync(configPath)) {
     throw new MessageError(
@@ -172,6 +172,11 @@ module.exports = {
           description: 'Serves both platforms',
         },
       ],
+    },
+    {
+      name: 'config',
+      description: 'Path to config file, eg. webpack.haul.js',
+      default: 'webpack.haul.js',
     },
   ],
 };

--- a/src/messages/webpackConfigNotFound.js
+++ b/src/messages/webpackConfigNotFound.js
@@ -8,7 +8,7 @@ const dedent = require('dedent');
 const chalk = require('chalk');
 
 module.exports = ({ directory }: { directory: string }) => dedent`
-   Couldn't find configuration file in ${chalk.bold(directory)}
+   Couldn't find configuration file ${chalk.bold(directory)}
 
    Make sure:
    • You are running haul from your project directory

--- a/src/utils/getWebpackConfig.js
+++ b/src/utils/getWebpackConfig.js
@@ -1,0 +1,24 @@
+const path = require('path');
+const fs = require('fs');
+const { MessageError } = require('../errors');
+const messages = require('../messages');
+
+module.exports = function getWebpackConfig(cwd: string, config: string) {
+  let configPath;
+
+  if (path.isAbsolute(config)) {
+    configPath = config;
+  } else {
+    configPath = path.join(cwd, config);
+  }
+
+  if (!fs.existsSync(configPath)) {
+    throw new MessageError(
+      messages.webpackConfigNotFound({
+        configPath,
+      }),
+    );
+  }
+
+  return configPath;
+};


### PR DESCRIPTION
Allow to specify the path to the config file as an option

`haul start --config ./path/to/config.js`