### PR TITLE
[WIP] Add initial support for HMR

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "strip-ansi": "^3.0.1",
     "webpack": "^2.3.1",
     "webpack-dev-middleware": "^1.10.1",
+    "webpack-hot-middleware": "^2.18.0",
     "ws": "^2.2.2"
   },
   "devDependencies": {

--- a/src/commands/start.js
+++ b/src/commands/start.js
@@ -40,6 +40,8 @@ async function start(opts: *) {
       root: directory,
       dev: opts.dev,
       minify: opts.minify,
+      hot: opts.hot,
+      port: opts.port,
     },
   );
 
@@ -170,6 +172,22 @@ module.exports = {
         {
           value: 'all',
           description: 'Serves both platforms',
+        },
+      ],
+    },
+    {
+      name: 'hot',
+      description: 'Enable hot module replacement',
+      default: false,
+      parse: (val: string) => val !== 'false',
+      choices: [
+        {
+          value: true,
+          description: 'Enables hot module replacement',
+        },
+        {
+          value: false,
+          description: 'Disables hot module replacement',
         },
       ],
     },

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -16,6 +16,7 @@ type CompileCallback = (stats: WebpackStats) => void;
  * Custom made middlewares
  */
 const webpackDevMiddleware = require('webpack-dev-middleware');
+const webpackHotMiddleware = require('webpack-hot-middleware');
 const devToolsMiddleware = require('./middleware/devToolsMiddleware');
 const liveReloadMiddleware = require('./middleware/liveReloadMiddleware');
 const statusPageMiddleware = require('./middleware/statusPageMiddleware');
@@ -64,6 +65,7 @@ function createServer(
     .use('/systrace', systraceMiddleware)
     .use(loggerMiddleware)
     .use(webpackMiddleware)
+    .use(webpackHotMiddleware(compiler))
     .use(missingBundleMiddleware);
 
   // Handle callbacks

--- a/yarn.lock
+++ b/yarn.lock
@@ -74,6 +74,10 @@ ansi-escapes@^1.0.0, ansi-escapes@^1.1.0, ansi-escapes@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-1.4.0.tgz#d3a8a83b319aa67793662b13e761c7911422306e"
 
+ansi-html@0.0.7:
+  version "0.0.7"
+  resolved "https://registry.yarnpkg.com/ansi-html/-/ansi-html-0.0.7.tgz#813584021962a9e9e6fd039f940d12f56ca7859e"
+
 ansi-regex@^2.0.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-2.1.1.tgz#c3b33ab5ee360d86e0e628f0468ae7ef27d654df"
@@ -846,10 +850,6 @@ babel-types@^6.18.0, babel-types@^6.19.0, babel-types@^6.22.0, babel-types@^6.23
     esutils "^2.0.2"
     lodash "^4.2.0"
     to-fast-properties "^1.0.1"
-
-babel@^6.23.0:
-  version "6.23.0"
-  resolved "https://registry.yarnpkg.com/babel/-/babel-6.23.0.tgz#d0d1e7d803e974765beea3232d4e153c0efb90f4"
 
 babylon@6.15.0:
   version "6.15.0"
@@ -2300,6 +2300,10 @@ html-encoding-sniffer@^1.0.1:
   resolved "https://registry.yarnpkg.com/html-encoding-sniffer/-/html-encoding-sniffer-1.0.1.tgz#79bf7a785ea495fe66165e734153f363ff5437da"
   dependencies:
     whatwg-encoding "^1.0.1"
+
+html-entities@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/html-entities/-/html-entities-1.2.0.tgz#41948caf85ce82fed36e4e6a0ed371a6664379e2"
 
 http-errors@~1.6.1:
   version "1.6.1"
@@ -3764,7 +3768,7 @@ querystring-es3@^0.2.0:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/querystring-es3/-/querystring-es3-0.2.1.tgz#9ec61f79049875707d69414596fd907a4d711e73"
 
-querystring@0.2.0:
+querystring@0.2.0, querystring@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/querystring/-/querystring-0.2.0.tgz#b209849203bb25df820da756e747005878521620"
 
@@ -4563,6 +4567,15 @@ webpack-dev-middleware@^1.10.1:
     mime "^1.3.4"
     path-is-absolute "^1.0.0"
     range-parser "^1.0.3"
+
+webpack-hot-middleware@^2.18.0:
+  version "2.18.0"
+  resolved "https://registry.yarnpkg.com/webpack-hot-middleware/-/webpack-hot-middleware-2.18.0.tgz#a16bb535b83a6ac94a78ac5ebce4f3059e8274d3"
+  dependencies:
+    ansi-html "0.0.7"
+    html-entities "^1.2.0"
+    querystring "^0.2.0"
+    strip-ansi "^3.0.0"
 
 webpack-sources@^0.2.3:
   version "0.2.3"


### PR DESCRIPTION
This adds initial support for HMR but is still not working.

Specifically, calls to `module.hot.check` time out when retrieving the manifest and `webpack-hot-middleware` will require an additional polyfill for `window.EventSource` to satisfy [this](https://github.com/glenjamin/webpack-hot-middleware/blob/40745357fa0c069204d01c993371bdbcd2e6fc74/client.js#L35-L45) so that it works without having remote JS debugging enabled.

Would love to hear some feedback on this.

cc: @satya164 