### PR TITLE
Opens an editor when tapping a stack frame.

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "loader-utils": "^1.1.0",
     "minimist": "^1.2.0",
     "morgan": "^1.8.1",
+    "open-in-editor": "^2.2.0",
     "opn": "^4.0.2",
     "ora": "^1.2.0",
     "progress-bar-webpack-plugin": "^1.9.3",

--- a/src/messages/editorNotConfigured.js
+++ b/src/messages/editorNotConfigured.js
@@ -13,11 +13,9 @@ module.exports = () => dedent`
 
   --- Easiest (auto-detect) ---
 
-    ${chalk.bold('export HAUL_EDITOR=code')}
+    ${chalk.bold('export REACT_EDITOR=code')}
     ${chalk.gray('or')}
-    ${chalk.bold('export HAUL_EDITOR=/path/to/atom')}
-    ${chalk.gray('or')}
-    ${chalk.bold('export REACT_EDITOR=/usr/local/bin/vim')}
+    ${chalk.bold('export REACT_EDITOR=/path/to/atom')}
 
     ${chalk.gray('(sublime, atom, code, webstorm, phpstorm, idea14ce, vim, emacs, visualstudio)')}
     ${chalk.gray('via https://github.com/lahmatiy/open-in-editor')}
@@ -25,12 +23,17 @@ module.exports = () => dedent`
 
   --- Harder (you have a custom script or symlink) ---
 
-    ${chalk.bold('export HAUL_EDITOR=sublime')}
-    ${chalk.bold('export HAUL_EDITOR_CMD="/Users/steve/betas/Sublime Beta.app"')}
+    ${chalk.bold('export REACT_EDITOR=vim')}
+    ${chalk.bold('export REACT_EDITOR_CMD=/usr/local/bin/nvim')}
   
+    ${chalk.gray('You can use this if you have recognized editor, but in non-standard location.')}
+
 
   --- Hardest (completely custom -- hold my beer) ---
 
-    ${chalk.bold('export HAUL_EDITOR_CMD=/path/to/a/crazy/editor')}
-    ${chalk.bold('export HAUL_EDITOR_PATTERN="-r -g {filename}:{line}:{column}"')}
+    ${chalk.bold('export REACT_EDITOR_CMD=/path/to/a/crazy/editor')}
+    ${chalk.bold('export REACT_EDITOR_PATTERN="-r -g {filename}:{line}:{column}"')}
+
+    ${chalk.gray('You can use this if your editor is unknown or you want to launch with different flags.')}
+
 `;

--- a/src/messages/editorNotConfigured.js
+++ b/src/messages/editorNotConfigured.js
@@ -1,0 +1,36 @@
+/**
+ * Copyright 2017-present, Callstack.
+ * All rights reserved.
+ *
+ * @flow
+ */
+
+const chalk = require('chalk');
+const dedent = require('dedent');
+
+module.exports = () => dedent`
+  Unable to open in editor. You can set environment variables to open your editor.
+
+  --- Easiest (auto-detect) ---
+
+    ${chalk.bold('export HAUL_EDITOR=code')}
+    ${chalk.gray('or')}
+    ${chalk.bold('export HAUL_EDITOR=/path/to/atom')}
+    ${chalk.gray('or')}
+    ${chalk.bold('export REACT_EDITOR=/usr/local/bin/vim')}
+
+    ${chalk.gray('(sublime, atom, code, webstorm, phpstorm, idea14ce, vim, emacs, visualstudio)')}
+    ${chalk.gray('via https://github.com/lahmatiy/open-in-editor')}
+
+
+  --- Harder (you have a custom script or symlink) ---
+
+    ${chalk.bold('export HAUL_EDITOR=sublime')}
+    ${chalk.bold('export HAUL_EDITOR_CMD="/Users/steve/betas/Sublime Beta.app"')}
+  
+
+  --- Hardest (completely custom -- hold my beer) ---
+
+    ${chalk.bold('export HAUL_EDITOR_CMD=/path/to/a/crazy/editor')}
+    ${chalk.bold('export HAUL_EDITOR_PATTERN="-r -g {filename}:{line}:{column}"')}
+`;

--- a/src/messages/index.js
+++ b/src/messages/index.js
@@ -31,4 +31,5 @@ module.exports = {
   gitAddedEntries: require('./gitAddedEntries'),
   gitAlreadyAdded: require('./gitAlreadyAdded'),
   gitNotFound: require('./gitNotFound'),
+  editorNotConfigured: require('./editorNotConfigured'),
 };

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -20,6 +20,7 @@ const devToolsMiddleware = require('./middleware/devToolsMiddleware');
 const liveReloadMiddleware = require('./middleware/liveReloadMiddleware');
 const statusPageMiddleware = require('./middleware/statusPageMiddleware');
 const symbolicateMiddleware = require('./middleware/symbolicateMiddleware');
+const openInEditorMiddleware = require('./middleware/openInEditorMiddleware');
 const loggerMiddleware = require('./middleware/loggerMiddleware');
 const missingBundleMiddleware = require('./middleware/missingBundleMiddleware');
 const systraceMiddleware = require('./middleware/systraceMiddleware');
@@ -61,6 +62,7 @@ function createServer(
     .use(liveReloadMiddleware(compiler))
     .use(statusPageMiddleware)
     .use(symbolicateMiddleware(compiler))
+    .use(openInEditorMiddleware())
     .use('/systrace', systraceMiddleware)
     .use(loggerMiddleware)
     .use(webpackMiddleware)

--- a/src/server/middleware/openInEditorMiddleware.js
+++ b/src/server/middleware/openInEditorMiddleware.js
@@ -1,0 +1,148 @@
+/**
+ * Copyright 2017-present, Callstack.
+ * All rights reserved.
+ *
+ * @flow
+ *
+ * --- OVERVIEW ---
+ *
+ * React Native apps show a stack trace when an error occurs. Each
+ * frame can be tapped on by the user. When they do, React Native will
+ * send a POST to /open-stack-frame passing along {file, lineNumber}.
+ *
+ * Haul should then open the user's editor to the file and lineNumber.
+ *
+ * What makes this gloriously fragile is, people use different editors
+ * on different platforms.
+ *
+ * We will rely on the NPM package `open-in-editor` to provide this
+ * functionality. (read: scapegoat).
+ */
+import type { $Request, $Response, Middleware } from 'express';
+import type { ReactNativeStackFrame } from '../../types';
+
+// A configuration object fed into `open-in-editor`.
+type OpenInEditorConfig = {
+  editor?: string | null,
+  cmd?: string | null,
+  pattern?: string | null,
+};
+
+const basename = require('path').basename;
+const openInEditor = require('open-in-editor');
+const editors = Object.keys(require('open-in-editor/lib/editors'));
+const messages = require('../../messages');
+const logger = require('../../logger');
+
+// does `open-in-editor` know how to detect this editor?
+const isKnownEditor = (editor: string): boolean =>
+  editors.indexOf(basename(editor)) >= 0;
+
+/**
+ * Detect the editor type to use. We use just the basename in case the user
+ * has passed a full path. Just the name work here though. Examples:
+ *
+ *   - sublime
+ *   - atom
+ *   - /usr/local/bin/atom
+ *
+ */
+function detectEditorType(): string | null {
+  // check for HAUL_EDITOR first
+  if (process.env.HAUL_EDITOR) {
+    const editor = basename(process.env.HAUL_EDITOR);
+    if (isKnownEditor(editor)) return editor;
+  }
+
+  // fallback to REACT_EDITOR
+  if (process.env.REACT_EDITOR) {
+    const editor = basename(process.env.REACT_EDITOR);
+    if (isKnownEditor(editor)) return editor;
+  }
+
+  return null;
+}
+
+/**
+ * If provided, this will be the editor command that we shell out to. You only
+ * need to use this if you've got a specific script or symlink you're trying
+ * to target.
+ */
+function detectEditorCmd(): string | null {
+  // the specific haul command gets precident
+  if (process.env.HAUL_EDITOR_CMD) return process.env.HAUL_EDITOR_CMD;
+
+  // use HAUL_EDITOR unless it's a shortcut (like just the word 'atom')
+  if (process.env.HAUL_EDITOR && !isKnownEditor(process.env.HAUL_EDITOR)) {
+    return process.env.HAUL_EDITOR;
+  }
+
+  // fallback to REACT_EDITOR
+  if (process.env.REACT_EDITOR && !isKnownEditor(process.env.REACT_EDITOR)) {
+    return process.env.REACT_EDITOR;
+  }
+
+  return null;
+}
+
+/**
+ * If provided, this allows people to control how the arguments are passed
+ * to their editor.  For example: -r -g {filename}:{line}:{column}
+ */
+function detectEditorPattern(): string | null {
+  return process.env.HAUL_EDITOR_PATTERN || null;
+}
+
+// configure the editor open library
+const editorConfig: OpenInEditorConfig = {};
+editorConfig.editor = detectEditorType();
+editorConfig.cmd = detectEditorCmd();
+
+// null is a valid pattern, so we need to only add it if we mean it
+const pattern = detectEditorPattern();
+if (pattern) {
+  editorConfig.pattern = pattern;
+}
+
+const hasValidConfig = editorConfig.editor || editorConfig.cmd;
+
+// create the middleware
+function create(): Middleware {
+  // create an editor we'll use to open editor.
+  const opener = openInEditor.configure(editorConfig);
+
+  /**
+   * The Express middleware for opening in the editor.
+   */
+  function openInEditorMiddleware(req: $Request, res: $Response, next) {
+    // only allow the appropriate path
+    if (req.path !== '/open-stack-frame') return next();
+
+    // prevent corner cases from blowing up
+    if (typeof req.rawBody !== 'string') {
+      return next();
+    }
+
+    // parse the inbound request as JSON
+    const frame: ReactNativeStackFrame = JSON.parse(req.rawBody);
+
+    // open it with the user's editor. the extra hasValidConfig check effectively
+    // turns off `open-in-editor`'s auto detection, which i found didn't work.
+    if (opener && hasValidConfig) {
+      opener.open(`${frame.file}:${frame.lineNumber}:${frame.column}`).then(
+        () => null, // no-op if we're successful
+        () => logger.warn(messages.editorNotConfigured()), // problem opening?
+      );
+    } else {
+      logger.warn(messages.editorNotConfigured());
+    }
+
+    // reassure React Native that everything is fine
+    res.end('OK');
+    return null;
+  }
+
+  return openInEditorMiddleware;
+}
+
+module.exports = create;

--- a/src/server/middleware/symbolicateMiddleware.js
+++ b/src/server/middleware/symbolicateMiddleware.js
@@ -17,21 +17,13 @@
  *
  */
 import type { $Request, Middleware } from 'express';
+import type { ReactNativeStackFrame, ReactNativeStack } from '../../types';
 
 const SourceMapConsumer = require('source-map').SourceMapConsumer;
 const path = require('path');
 const delve = require('dlv');
 const messages = require('../../messages');
 const logger = require('../../logger');
-
-type ReactNativeStackFrame = {
-  lineNumber: number,
-  column: number,
-  file: string,
-  methodName: string,
-};
-
-type ReactNativeStack = Array<ReactNativeStackFrame>;
 
 type ReactNativeSymbolicateRequest = {
   stack: ReactNativeStack,

--- a/src/types.js
+++ b/src/types.js
@@ -42,3 +42,12 @@ export type Logger = {
   done: LoggerPrint,
   debug: LoggerPrint,
 };
+
+export type ReactNativeStackFrame = {
+  lineNumber: number,
+  column: number,
+  file: string,
+  methodName: string,
+};
+
+export type ReactNativeStack = Array<ReactNativeStackFrame>;

--- a/yarn.lock
+++ b/yarn.lock
@@ -847,10 +847,6 @@ babel-types@^6.18.0, babel-types@^6.19.0, babel-types@^6.22.0, babel-types@^6.23
     lodash "^4.2.0"
     to-fast-properties "^1.0.1"
 
-babel@^6.23.0:
-  version "6.23.0"
-  resolved "https://registry.yarnpkg.com/babel/-/babel-6.23.0.tgz#d0d1e7d803e974765beea3232d4e153c0efb90f4"
-
 babylon@6.15.0:
   version "6.15.0"
   resolved "https://registry.yarnpkg.com/babylon/-/babylon-6.15.0.tgz#ba65cfa1a80e1759b0e89fb562e27dccae70348e"
@@ -1111,6 +1107,12 @@ cipher-base@^1.0.0, cipher-base@^1.0.1:
 circular-json@^0.3.1:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/circular-json/-/circular-json-0.3.1.tgz#be8b36aefccde8b3ca7aa2d6afc07a37242c0d2d"
+
+clap@^1.1.3:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/clap/-/clap-1.1.3.tgz#b3bd36e93dd4cbfb395a3c26896352445265c05b"
+  dependencies:
+    chalk "^1.1.3"
 
 clear@^0.0.1:
   version "0.0.1"
@@ -3465,6 +3467,13 @@ onetime@^2.0.0:
   dependencies:
     mimic-fn "^1.0.0"
 
+open-in-editor@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/open-in-editor/-/open-in-editor-2.2.0.tgz#c5b21aa76f6acd4cbbd3c3b2e77dccb4b75a2020"
+  dependencies:
+    clap "^1.1.3"
+    os-homedir "~1.0.2"
+
 opn@^4.0.2:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/opn/-/opn-4.0.2.tgz#7abc22e644dff63b0a96d5ab7f2790c0f01abc95"
@@ -3512,7 +3521,7 @@ os-browserify@^0.2.0:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/os-browserify/-/os-browserify-0.2.1.tgz#63fc4ccee5d2d7763d26bbf8601078e6c2e0044f"
 
-os-homedir@^1.0.0, os-homedir@^1.0.1:
+os-homedir@^1.0.0, os-homedir@^1.0.1, os-homedir@~1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/os-homedir/-/os-homedir-1.0.2.tgz#ffbc4988336e0e833de0c168c7ef152121aa7fb3"
 


### PR DESCRIPTION
This PR adds support for tapping on a stack trace in the simulator.  It will open the user's editor to the right line/column.

There's a few ways to use it, here's the easiest:

```sh
export REACT_EDITOR=code
```

This works too:

```sh
export REACT_EDITOR=/usr/local/bin/code
```

[The library we're using](https://github.com/lahmatiy/open-in-editor) supports about a dozen editors and it knows where to look for the standard installs.  It knows how to launch them and use the right order for parameters.

For custom installs, we had to invent some things:

```sh
export HAUL_EDITOR=sublime
export HAUL_EDITOR_CMD="/path/to/Sublime Super Mega Beta.app"
export HAUL_EDITOR_PATTERN="-r -g {filename}:{line}:{column}"
```

That's for more advanced setups.

Out of the box, if no environment variables are found, it prints some instructions:

![image](https://cloud.githubusercontent.com/assets/68273/25322280/789cc2d4-2883-11e7-8a4c-916488f0d076.png)

I've tried atom, code, vim, and sublime on MacOS 10.11.6.  I haven't tried on Windows or Linux, however, the library we're using supports those.  I will give it a test tomorrow on both and sound the air raid horns if something is awry.

Vim opens up in Terminal, not iTerm.  This makes me sad in the pants.  I don't know how to fix.

Feedback welcome. (e.g. should we add a command line option too?).

Fixes #123 
