### PR TITLE
Remove package.json script

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ project.ext.react = [
 To configure your project to use haul, run the following:
 
 ```bash
-yarn run haul init
+yarn haul init
 ```
 
 This will automatically add the configuration needed to make Haul work with your app, e.g. add `webpack.haul.js` to your project, which you can customise to add more functionality.
@@ -46,7 +46,7 @@ This will automatically add the configuration needed to make Haul work with your
 Next, you're ready to start the development server:
 
 ```bash
-yarn run haul start -- --platform ios
+yarn haul start -- --platform ios
 ```
 
 Finally, reload your app to update the bundle or run your app just like you normally would:
@@ -72,7 +72,7 @@ Haul uses a completely different architecture from React Native packager, which 
 
 We are actively working on adding support for the following:
 
-- Existing `react-native` commands 
+- Existing `react-native` commands
 
 The following features are **unlikely to be supported** in the future:
 

--- a/src/commands/init.js
+++ b/src/commands/init.js
@@ -127,7 +127,6 @@ async function init() {
   }
 
   await addToXcodeBuild(cwd);
-  await addToPackageScripts(cwd);
 
   progress = ora(messages.generatingConfig()).start();
 
@@ -146,70 +145,6 @@ async function init() {
 
 const sleep = (time: number = 1000) =>
   new Promise(resolve => setTimeout(resolve, time));
-
-const getRunScript = (scriptName: string) => {
-  const runCommand = scriptName === 'start' ? 'yarn' : 'yarn run';
-  return `${runCommand} ${scriptName}`;
-};
-
-/**
- * Adds Haul to package.json scripts
- */
-const addToPackageScripts = async (cwd: string) => {
-  const pjson = JSON.parse(
-    fs.readFileSync(path.join(cwd, 'package.json')).toString(),
-  );
-
-  const scripts = pjson.scripts || {};
-
-  const haulScript = Object.keys(scripts).find(
-    name => scripts[name] === 'haul start',
-  );
-
-  if (haulScript) {
-    ora().info(
-      `Haul already exists in your package.json. Start Haul by running ${getRunScript(haulScript)}'`,
-    );
-    return;
-  }
-
-  let scriptName = 'start';
-
-  if (
-    scripts.start &&
-    scripts.start !== 'node ./node_modules/react-native/local-cli/cli.js start'
-  ) {
-    const result = await inquirer.prompt([
-      {
-        type: 'input',
-        name: 'scriptName',
-        message: 'Enter the name of the script to add to package.json, e.g. `haul` for `yarn run haul`',
-        default: 'haul',
-      },
-    ]);
-
-    scriptName = result.scriptName;
-  }
-
-  pjson.scripts = Object.assign({}, scripts, {
-    [scriptName]: 'haul start',
-  });
-
-  const progress = ora(
-    `Adding \`${scriptName}\` script to your package.json`,
-  ).start();
-
-  await sleep();
-
-  fs.writeFileSync(
-    path.join(cwd, 'package.json'),
-    JSON.stringify(pjson, null, 2),
-  );
-
-  progress.succeed(
-    `You can now start Haul by running '${getRunScript(scriptName)}'`,
-  );
-};
 
 /**
  * Adds Haul to native iOS build pipeline
@@ -263,7 +198,7 @@ const addToXcodeBuild = async (cwd: string) => {
 
   /**
    * Define Haul integration script in the PBXShellScriptBuildPhase section.
-   * 
+   *
    * This is done by prepending our predefined script phase to the list
    * of all phases.
    */
@@ -289,9 +224,9 @@ const addToXcodeBuild = async (cwd: string) => {
 
   /**
    * Add Haul integration to build phases that already contain `react-native-xcode.sh`
-   * 
+   *
    * We are typically trying to match the following:
-   * 
+   *
    * ```
    *   buildPhases = (
    *     13B07F871A680F5B00A75B9A \/* Sources *\/,


### PR DESCRIPTION
Default name of package.json script is `haul` and defaults to `haul start`. Having that value set, it makes it hard for others to run other commands, since now `yarn haul` executes such script.

By removing that phase and package.json script entirely, users can just run `yarn haul start` or any other option. 

Also, it eliminates confusion since in docs, we recommend executing through `yarn`.