### PR TITLE
Use new name

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,14 +24,14 @@ Haul is a drop-in replacement for `react-native` CLI built on open tools like We
 Start by adding Haul as a dependency to your React Native project (use `react-native init MyProject` to create one if you don't have a project):
 
 ```bash
-yarn add --dev haul-cli
+yarn add --dev haul
 ```
 
 If you're on a React Native version >= 0.43, add the following in `android/app/build.gradle` somewhere before the `apply from: "../../node_modules/react-native/react.gradle"` statement:
 
 ```
 project.ext.react = [
-    cliPath: "node_modules/haul-cli/bin/cli.js"
+    cliPath: "node_modules/haul/bin/cli.js"
 ]
 ```
 
@@ -72,7 +72,7 @@ Haul uses a completely different architecture from React Native packager, which 
 
 We are actively working on adding support for the following:
 
-- Existing `react-native` commands 
+- Existing `react-native` commands
 
 The following features are **unlikely to be supported** in the future:
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "version": "0.6.0",
-  "name": "haul-cli",
+  "name": "haul",
   "description": "Haul is a new command line tools for React Native",
   "bin": {
     "haul": "./bin/cli.js"

--- a/src/commands/init.js
+++ b/src/commands/init.js
@@ -263,7 +263,7 @@ const addToXcodeBuild = async (cwd: string) => {
 
   /**
    * Define Haul integration script in the PBXShellScriptBuildPhase section.
-   * 
+   *
    * This is done by prepending our predefined script phase to the list
    * of all phases.
    */
@@ -283,15 +283,15 @@ const addToXcodeBuild = async (cwd: string) => {
         );
         runOnlyForDeploymentPostprocessing = 0;
         shellPath = /bin/sh;
-        shellScript = "bash ../node_modules/haul-cli/src/utils/haul-integrate.sh";
+        shellScript = "bash ../node_modules/haul/src/utils/haul-integrate.sh";
       };`,
   );
 
   /**
    * Add Haul integration to build phases that already contain `react-native-xcode.sh`
-   * 
+   *
    * We are typically trying to match the following:
-   * 
+   *
    * ```
    *   buildPhases = (
    *     13B07F871A680F5B00A75B9A \/* Sources *\/,


### PR DESCRIPTION
Now that I have access to `haul` on npm, we can switch to it.