### PR TITLE
Fix findProvidesModule throwing error in while running start command

### DIFF
--- a/src/utils/findProvidesModule.js
+++ b/src/utils/findProvidesModule.js
@@ -57,7 +57,7 @@ function findProvidesModule(directories, opts = {}) {
   const modulesMap = {};
 
   const walk = dir => {
-    const stat = fs.statSync(dir);
+    const stat = fs.lstatSync(dir);
 
     if (stat.isDirectory()) {
       fs.readdirSync(dir).forEach(file => {

--- a/src/utils/resolveModule.js
+++ b/src/utils/resolveModule.js
@@ -12,7 +12,7 @@ const resolver = require('resolve');
 * We point to 'package.json', then remove it to receive a path to the directory itself
 */
 
-module.exports = (root, name) =>
+module.exports = (root: string, name: string) =>
   resolver
     .sync(`${name}/package.json`, { basedir: root })
     .replace('/package.json', '');


### PR DESCRIPTION
### Current Behavior
1. `react-native init testApp`
2. `cd testApp && yarn add haul`
3. `yarn run haul -- --platform ios`
4. `react-native run-ios` (in other tab)
5. Stop `haul` by Ctrl+C and run again: `yarn run haul -- --platform ios`
```
 ERROR  Error running yarn run haul -- --platform ios

Error: ENOENT: no such file or directory, stat '/Users/paweltrysla/Documents/TrueCar/testRNApp/node_modules/react-native/third-party/glog-0.3.4/test-driver'
at Object.fs.statSync (fs.js:968:11)
at walk (/Users/paweltrysla/Documents/TrueCar/testRNApp/node_modules/haul/src/utils/findProvidesModule.js:60:21)
at fs.readdirSync.forEach.file (/Users/paweltrysla/Documents/TrueCar/testRNApp/node_modules/haul/src/utils/findProvidesModule.js:67:9)
at Array.forEach (native)
at walk (/Users/paweltrysla/Documents/TrueCar/testRNApp/node_modules/haul/src/utils/findProvidesModule.js:63:27)
at fs.readdirSync.forEach.file (/Users/paweltrysla/Documents/TrueCar/testRNApp/node_modules/haul/src/utils/findProvidesModule.js:67:9)
at Array.forEach (native)
at walk (/Users/paweltrysla/Documents/TrueCar/testRNApp/node_modules/haul/src/utils/findProvidesModule.js:63:27)
at fs.readdirSync.forEach.file (/Users/paweltrysla/Documents/TrueCar/testRNApp/node_modules/haul/src/utils/findProvidesModule.js:67:9)
at Array.forEach (native)
```

### Expected Behavior
No error
### Your Environment

| software         | version
| ---------------- | -------
| Haul             |  `1.0.0-beta.0`
| react-native     |  `0.45.1`
| node             | `7.10.0`
| npm or yarn      | `yarn 0.23.4`


After first run of `react-native run-ios` in freshly created project, `/Users/paweltrysla/Documents/TrueCar/testRNApp/node_modules/react-native/third-party/glog-0.3.4/test-driver` is replaced with symlink, thus `fs.statSync` (https://github.com/callstack-io/haul/blob/master/src/utils/findProvidesModule.js#L60) throws error. Quick fix is to replace it with `fs.lstatSync` which handles symbolic links correctly.