### PR TITLE
HasteResolver not resolving on Windows

### DIFF
--- a/src/utils/resolveModule.js
+++ b/src/utils/resolveModule.js
@@ -6,13 +6,15 @@
  */
 
 const resolver = require('resolve');
+const path = require('path');
 
 /**
 * Resolves the path to a given module
 * We point to 'package.json', then remove it to receive a path to the directory itself
 */
 
-module.exports = (root: string, name: string) =>
-  resolver
-    .sync(`${name}/package.json`, { basedir: root })
-    .replace(/(\\|\\\\|\/)package.json$/, '');
+module.exports = (root: string, name: string) => {
+  const filePath = resolver.sync(`${name}/package.json`, { basedir: root });
+
+  return path.dirname(filePath);
+};

--- a/src/utils/resolveModule.js
+++ b/src/utils/resolveModule.js
@@ -15,4 +15,4 @@ const resolver = require('resolve');
 module.exports = (root: string, name: string) =>
   resolver
     .sync(`${name}/package.json`, { basedir: root })
-    .replace('/package.json', '');
+    .replace(/(\\|\\\\|\/)package.json$/, '');


### PR DESCRIPTION
Fixed a bug where we did not remove `package.json` from directories' path.

Fixes #170 and #175 