### PR TITLE
Better Error messages

### DIFF
--- a/src/server/assets/debuggerWorker.js
+++ b/src/server/assets/debuggerWorker.js
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-/* global __fbBatchedBridge, self, importScripts, postMessage, onmessage: true */
+/* global __fbBatchedBridge, self, importScripts, postMessage, onmessage: true */ // eslint-disable-line
 
 /* eslint-disable */
 
@@ -35,13 +35,14 @@ onmessage = (function() {
       for (const key in message.inject) {
         self[key] = JSON.parse(message.inject[key]);
       }
-      let error;
+      let error; //
       try {
         importScripts(message.url);
       } catch (err) {
-        error = JSON.stringify(err);
+        self.ErrorUtils.reportFatalError(err);
+      } finally {
+        sendReply(null /* result */, error);
       }
-      sendReply(null /* result */, error);
     },
     setDebuggerVisibility(message) {
       visibilityState = message.visibilityState;

--- a/src/server/assets/debuggerWorker.js
+++ b/src/server/assets/debuggerWorker.js
@@ -35,14 +35,18 @@ onmessage = (function() {
       for (const key in message.inject) {
         self[key] = JSON.parse(message.inject[key]);
       }
-      let error; //
-      try {
-        importScripts(message.url);
-      } catch (err) {
-        self.ErrorUtils.reportFatalError(err);
-      } finally {
-        sendReply(null /* result */, error);
+
+      function evalJS(js) {
+        try {
+          eval(js);
+        } catch (e) {
+          self.ErrorUtils.reportFatalError(e);
+        } finally {
+          self.postMessage({ replyID: message.id });
+        }
       }
+
+      fetch(message.url).then(resp => resp.text()).then(evalJS);
     },
     setDebuggerVisibility(message) {
       visibilityState = message.visibilityState;

--- a/src/server/middleware/symbolicateMiddleware.js
+++ b/src/server/middleware/symbolicateMiddleware.js
@@ -74,13 +74,33 @@ function getRequestedFrames(req: $Request): ?ReactNativeStack {
     return null;
   }
 
+  let stack;
+
   try {
     const payload: ReactNativeSymbolicateRequest = JSON.parse(req.rawBody);
-    return payload.stack;
+    stack = payload.stack;
   } catch (err) {
     // should happen, but at least we won't die
-    return null;
+    stack = null;
   }
+
+  const newStack = stack.filter(stackLine => {
+    const { methodName } = stackLine;
+    const unwantedStackRegExp = new RegExp(
+      /(__webpack_require__|haul|eval(JS){0,1})/,
+    );
+
+    if (unwantedStackRegExp.test(methodName)) return false; // we don't need those
+
+    const evalLine = methodName.indexOf('Object../');
+    if (evalLine > -1) {
+      const newMethodName = methodName.slice(evalLine + 9); // removing this prefix in method names
+      stackLine.methodName = newMethodName; // eslint-disable-line
+    }
+    return true;
+  });
+
+  return newStack;
 }
 
 /**

--- a/src/server/middleware/symbolicateMiddleware.js
+++ b/src/server/middleware/symbolicateMiddleware.js
@@ -84,6 +84,8 @@ function getRequestedFrames(req: $Request): ?ReactNativeStack {
     stack = null;
   }
 
+  if (!stack) return null;
+
   const newStack = stack.filter(stackLine => {
     const { methodName } = stackLine;
     const unwantedStackRegExp = new RegExp(


### PR DESCRIPTION
Before:
<img width="242" alt="screen shot 2017-06-29 at 15 31 00" src="https://user-images.githubusercontent.com/6444719/27690439-a11a8fce-5ce1-11e7-8280-cc09d5703528.png">

After:
<img width="239" alt="screen shot 2017-06-29 at 15 31 39" src="https://user-images.githubusercontent.com/6444719/27690445-a5889fba-5ce1-11e7-87fc-a021ed41a322.png">

Errors are visible now, but stack trace is pointing back to `worker`.
Still WIP.
- [X] Better Error messages
- [x] Proper stack trace
