### PR TITLE
Adds error symbolication in multi-platform mode.

### DIFF
--- a/src/messages/index.js
+++ b/src/messages/index.js
@@ -32,4 +32,5 @@ module.exports = {
   gitAlreadyAdded: require('./gitAlreadyAdded'),
   gitNotFound: require('./gitNotFound'),
   editorNotConfigured: require('./editorNotConfigured'),
+  webpackCompilerPlatformNotFound: require('./webpackCompilerPlatformNotFound'),
 };

--- a/src/messages/webpackCompilerPlatformNotFound.js
+++ b/src/messages/webpackCompilerPlatformNotFound.js
@@ -1,0 +1,16 @@
+/**
+ * Copyright 2017-present, Callstack.
+ * All rights reserved.
+ *
+ * @flow
+ */
+const chalk = require('chalk');
+const dedent = require('dedent');
+
+module.exports = (platform: ?string) => dedent`
+  Unable to find a webpack compiler for ${chalk.bold(platform || '<null>')}.
+
+  Check your middleware to ensure you're passing the correct platform to getCompilerByPlatform().
+
+  Returning the first compiler in the list.  Your source maps *might* be off if you're using platform-specific code.
+`;

--- a/src/server/middleware/symbolicateMiddleware.js
+++ b/src/server/middleware/symbolicateMiddleware.js
@@ -24,6 +24,7 @@ const path = require('path');
 const delve = require('dlv');
 const messages = require('../../messages');
 const logger = require('../../logger');
+const getCompilerByPlatform = require('../../utils/getCompilerByPlatform');
 
 type ReactNativeSymbolicateRequest = {
   stack: ReactNativeStack,
@@ -86,20 +87,29 @@ function getRequestedFrames(req: $Request): ?ReactNativeStack {
 /**
  * Create an Express middleware for handling React Native symbolication requests
  */
-function create(compiler: *): Middleware {
+function create(webpackCompiler: *): Middleware {
   /**
    * The Express middleware for symbolicatin'.
    */
   function symbolicateMiddleware(req: $Request, res, next) {
     if (req.path !== '/symbolicate') return next();
 
-    // grab our source map consumer
-    const consumer = createSourceMapConsumer(compiler);
-    if (!consumer) return next();
-
     // grab the source stack frames
     const unconvertedFrames = getRequestedFrames(req);
     if (!unconvertedFrames) return next();
+
+    // grab the platform from the first frame (e.g. index.ios.bundle?platform=ios&dev=true&minify=false:69825:16)
+    const platformMatch = unconvertedFrames[0].file.match(
+      /platform=([a-zA-Z]*)/,
+    );
+    const platform: ?string = platformMatch && platformMatch[1];
+
+    // grab the appropriate webpack compiler
+    const compiler = getCompilerByPlatform(webpackCompiler, platform);
+
+    // grab our source map consumer
+    const consumer = createSourceMapConsumer(compiler);
+    if (!consumer) return next();
 
     // the base directory
     const root = compiler.options.context;

--- a/src/utils/getCompilerByPlatform.js
+++ b/src/utils/getCompilerByPlatform.js
@@ -1,0 +1,40 @@
+// @flow
+
+const messages = require('../messages');
+const logger = require('../logger');
+
+/**
+ * Get the proper webpack compiler.
+ *
+ * Since Haul can be run for a single platform (--platform ios|android) or multiple (--platform all),
+ * the passed in compiler might be a `MultiCompiler` instance which holds an array of compilers.
+ *
+ * @param {*} compiler The Webpack compiler passed into the express middleware.
+ * @param {?string} platform The platform to use.
+ */
+module.exports = function getCompilerByPlatform(
+  webpackCompiler: *,
+  platform: ?string,
+): * {
+  const isMulti = Boolean(webpackCompiler.compilers);
+
+  // we're running in single-platform mode so all is right in the universe.
+  if (!isMulti) {
+    return webpackCompiler;
+  }
+
+  // find the right compiler based on the platform in the bundle's output filename (e.g. index.android.js)
+  //   (see: makeReactNativeConfig.js -> getDefaultConfig)
+  const compiler = webpackCompiler.compilers.find(
+    c => c.options.output.filename.split('.')[1] === platform,
+  );
+
+  // sanity check
+  if (!compiler) {
+    logger.warn(messages.webpackCompilerPlatformNotFound(platform));
+    // chances are pretty good this will be "ok", but platform-specific code won't be
+    return webpackCompiler.compilers[0];
+  }
+
+  return compiler;
+};


### PR DESCRIPTION
### Overview

A fix for #176 which revealed that symbolication didn't work while in `--platform all` mode.

### Implementation Concerns

So, I had thought that React Native passed the platform when did it's symbolicate request.  It doesn't.  😿 

What I'm doing now is "detecting" it by looking at the first frame's unresolved filename.  Somewhere in there it'll say `...index.ios.bundle?platform=ios&...`.  I'm matching the platform found there against the webpack `options.output.filename` config.  

Not award-winning, but it works.  Would be nicer if there was a easier way to get the platform from the config.  I created a helper `getCompilerByPlatform` where we can put that.

### Sneaky Fallback

Something presumptuous I snuck in (I know @grabbou & @satya164 will rightfully call me out on this) is, if we can't find the platform (due to an error in the calling middleware), we fallback to the first compiler.  This will generally be ok unless you're using platform-specific code.

I can remove this if y'all aren't onboard.

### Other Potential Problems

@markbiddlecom mentioned this `MultiCompiler` issue might be in other middleware too.  He's right.  [This might be](https://github.com/callstack-io/haul/blob/master/src/server/middleware/liveReloadMiddleware.js#L32) an issue as well.

### Housekeeping

This may collide with with PR #183 so if you wanna merge that first, ping me and I'll rebase this.

