### PR TITLE
test react-native/packager is exist or not, if not use react-native/script

### DIFF
--- a/src/utils/haul-integrate.sh
+++ b/src/utils/haul-integrate.sh
@@ -2,7 +2,13 @@
 
 THIS_DIR=$(dirname $0)
 
-SRC="$(cd "${THIS_DIR}/../../../react-native/packager" && pwd)"
+SCRIPT_SRC="${THIS_DIR}/../../../react-native/packager"
+if [ ! -d "${SCRIPT_SRC}" ]; then
+  # Check if react-native/packager is exist, for >= 0.46 RN version.
+  SCRIPT_SRC="${THIS_DIR}/../../../react-native/scripts"
+fi
+
+SRC="$(cd "${SCRIPT_SRC}" && pwd)"
 
 # Replace local-cli with Haul in `react-native-xcode.sh`
 sed -i -e 's|$REACT_NATIVE_DIR/local-cli/cli.js|./node_modules/.bin/haul|' ${SRC}/react-native-xcode.sh

--- a/src/utils/haul-integrate.sh
+++ b/src/utils/haul-integrate.sh
@@ -3,8 +3,9 @@
 THIS_DIR=$(dirname $0)
 
 SCRIPT_SRC="${THIS_DIR}/../../../react-native/packager"
+
+# Check if react-native/packager exists, for React Native < 0.46
 if [ ! -d "${SCRIPT_SRC}" ]; then
-  # Check if react-native/packager is exist, for >= 0.46 RN version.
   SCRIPT_SRC="${THIS_DIR}/../../../react-native/scripts"
 fi
 


### PR DESCRIPTION
haul build failed in the latest RN version.

`react-native/packager` folder is no longer exist in RN 0.46, check if the folder is exist or not. if not use `react-native/script` folder

More information: 
https://github.com/facebook/react-native/issues/14935#issuecomment-314160539