### PR TITLE
Update SCRIPT_SRC to work with rn@0.46.4

### DIFF
--- a/src/utils/haul-integrate.sh
+++ b/src/utils/haul-integrate.sh
@@ -2,7 +2,7 @@
 
 THIS_DIR=$(dirname $0)
 
-SCRIPT_SRC="${THIS_DIR}/../../../react-native/packager"
+SCRIPT_SRC="${THIS_DIR}/../../../react-native/scripts"
 
 # Check if react-native/packager exists, for React Native < 0.46
 if [ ! -d "${SCRIPT_SRC}" ]; then


### PR DESCRIPTION
Otherwise, it would throw errors:
```
../node_modules/haul/src/utils/haul-integrate.sh: line 5: cd: ../node_modules/haul/src/utils/../../../react-native/packager: No such file or directory

sed: /react-native-xcode.sh: No such file or directory

../node_modules/haul/src/utils/haul-integrate.sh: line 12: /packager.sh: Permission denied


```