### PR TITLE
Fix `launchPackager` step from Xcode

### DIFF
--- a/src/utils/haul-integrate.sh
+++ b/src/utils/haul-integrate.sh
@@ -15,5 +15,5 @@ SRC="$(cd "${SCRIPT_SRC}" && pwd)"
 sed -i -e 's|$REACT_NATIVE_DIR/local-cli/cli.js|./node_modules/.bin/haul|' ${SRC}/react-native-xcode.sh
 
 # Replace `react-native start` in `packager.sh`
-PACKAGER_CONTENT="cd ../../../ && node \"./node_modules/.bin/haul\" start --platform ios \"\$@\""
+PACKAGER_CONTENT="cd \"$THIS_DIR/../../../\" && node \"./node_modules/.bin/haul\" start --platform ios \"\$@\""
 echo "$PACKAGER_CONTENT" > ${SRC}/packager.sh


### PR DESCRIPTION
When packager is being launched by Xcode during run phase (by `launchPackager.command`), current working directory is set to `/`. This results in an awkward error saying "Cannot find /node_modules/.bin/haul" (note it looks in wrong folder - in this case, top level one).

In order for this to function properly, we need to use $THIS_DIR variable that is set by `launchPackager.command` before executing `packager.sh` script.