### PR TITLE
Set mimetype for bundle files

### DIFF
--- a/src/server/index.js
+++ b/src/server/index.js
@@ -51,6 +51,7 @@ function createServer(
     reporter: null,
     stats: 'errors-only',
     hot: true,
+    mimeTypes: { 'application/javascript': ['bundle'] },
     watchOptions: {
       aggregateTimeout: 300,
       poll: 1000,


### PR DESCRIPTION
I failed at reading the webpack-dev-server code. It exposes a parameter for adding mime-type detection. This ensures that the `.bundle` file is served with an `application/javascript` content-type.

https://github.com/callstack-io/haul/pull/229 is unnecessary, but things are still broken pending fix of https://github.com/facebook/react-native/issues/15791